### PR TITLE
fix: use literal placeholders for Supabase env vars

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,8 +431,9 @@
     <script>
         // Supabase config
         // Priority: window globals -> localStorage -> placeholders
-        const SUPABASE_URL_PLACEHOLDER = ['YOUR', 'SUPABASE_URL'].join('_');
-        const SUPABASE_ANON_KEY_PLACEHOLDER = ['YOUR', 'SUPABASE_ANON_KEY'].join('_');
+        // Note: Placeholders are replaced by GitHub Actions during deployment
+        const SUPABASE_URL_PLACEHOLDER = 'YOUR_SUPABASE_URL';
+        const SUPABASE_ANON_KEY_PLACEHOLDER = 'YOUR_SUPABASE_ANON_KEY';
         const SUPABASE_URL = window.SUPABASE_URL || localStorage.getItem('mieleSnakeSupabaseUrl') || SUPABASE_URL_PLACEHOLDER;
         const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY || localStorage.getItem('mieleSnakeSupabaseAnonKey') || SUPABASE_ANON_KEY_PLACEHOLDER;
 


### PR DESCRIPTION
## Summary

The placeholders were constructed dynamically at runtime using `.join('_')`, which prevented the GitHub Actions sed commands from finding and replacing them. Changed to literal strings that can be matched by sed.

## Changes

- Changed `SUPABASE_URL_PLACEHOLDER` from `['YOUR', 'SUPABASE_URL'].join('_')` to literal `'YOUR_SUPABASE_URL'`
- Changed `SUPABASE_ANON_KEY_PLACEHOLDER` from dynamic to literal `'YOUR_SUPABASE_ANON_KEY'`

This allows the GitHub Actions workflow to correctly replace the placeholders during deployment.

## Testing

After merging, trigger a deployment to verify the leaderboard works.

---