### PR TITLE
fix: check for YOUR_SUPABASE placeholder instead of placeholder variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
                 return 'Supabase SDK failed to load (CDN blocked/offline)';
             }
 
-            if (!url || url.includes(SUPABASE_URL_PLACEHOLDER)) {
+            if (!url || url.includes('YOUR_SUPABASE_URL')) {
                 return 'Missing Supabase URL (placeholder not replaced; check SUPABASE_URL secret)';
             }
 
@@ -455,7 +455,7 @@
                 return 'Supabase URL is invalid';
             }
 
-            if (!anonKey || anonKey.includes(SUPABASE_ANON_KEY_PLACEHOLDER)) {
+            if (!anonKey || anonKey.includes('YOUR_SUPABASE_ANON_KEY')) {
                 return 'Missing Supabase anon key (placeholder not replaced; check SUPABASE_ANON_KEY secret)';
             }
 


### PR DESCRIPTION
## Summary

After the first fix, the check `url.includes(SUPABASE_URL_PLACEHOLDER)` was always true because SUPABASE_URL_PLACEHOLDER now contains the actual URL after replacement.

Changed to check for the original placeholder string 'YOUR_SUPABASE_URL' instead.

## Changes

- Line 445: `url.includes('YOUR_SUPABASE_URL')`
- Line 458: `anonKey.includes('YOUR_SUPABASE_ANON_KEY')`
