### PR TITLE
fix: use actual value validation instead of placeholder check

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
                 return 'Supabase SDK failed to load (CDN blocked/offline)';
             }
 
-            if (!url || url.includes('YOUR_SUPABASE_URL')) {
+            if (!url || !url.startsWith('https://') || !url.includes('.supabase')) {
                 return 'Missing Supabase URL (placeholder not replaced; check SUPABASE_URL secret)';
             }
 
@@ -455,7 +455,7 @@
                 return 'Supabase URL is invalid';
             }
 
-            if (!anonKey || anonKey.includes('YOUR_SUPABASE_ANON_KEY')) {
+            if (!anonKey || !anonKey.startsWith('eyJ') || anonKey.length < 20) {
                 return 'Missing Supabase anon key (placeholder not replaced; check SUPABASE_ANON_KEY secret)';
             }
 

--- a/index.html
+++ b/index.html
@@ -431,8 +431,9 @@
     <script>
         // Supabase config
         // Priority: window globals -> localStorage -> placeholders
-        const SUPABASE_URL_PLACEHOLDER = ['YOUR', 'SUPABASE_URL'].join('_');
-        const SUPABASE_ANON_KEY_PLACEHOLDER = ['YOUR', 'SUPABASE_ANON_KEY'].join('_');
+        // Note: Placeholders are replaced by GitHub Actions during deployment
+        const SUPABASE_URL_PLACEHOLDER = 'YOUR_SUPABASE_URL';
+        const SUPABASE_ANON_KEY_PLACEHOLDER = 'YOUR_SUPABASE_ANON_KEY';
         const SUPABASE_URL = window.SUPABASE_URL || localStorage.getItem('mieleSnakeSupabaseUrl') || SUPABASE_URL_PLACEHOLDER;
         const SUPABASE_ANON_KEY = window.SUPABASE_ANON_KEY || localStorage.getItem('mieleSnakeSupabaseAnonKey') || SUPABASE_ANON_KEY_PLACEHOLDER;
 

--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
                 return 'Supabase SDK failed to load (CDN blocked/offline)';
             }
 
-            if (!url || url.includes(SUPABASE_URL_PLACEHOLDER)) {
+            if (!url || url.includes('YOUR_SUPABASE_URL')) {
                 return 'Missing Supabase URL (placeholder not replaced; check SUPABASE_URL secret)';
             }
 
@@ -455,7 +455,7 @@
                 return 'Supabase URL is invalid';
             }
 
-            if (!anonKey || anonKey.includes(SUPABASE_ANON_KEY_PLACEHOLDER)) {
+            if (!anonKey || anonKey.includes('YOUR_SUPABASE_ANON_KEY')) {
                 return 'Missing Supabase anon key (placeholder not replaced; check SUPABASE_ANON_KEY secret)';
             }
 


### PR DESCRIPTION
## Problem

After the first fix, the sed replacement was replacing ALL occurrences of YOUR_SUPABASE_URL, including in the validation check code. This caused the check to always fail because it was checking if the URL contains itself.

## Fix

Changed the validation logic from checking for placeholder to actual value validation:

- URL: `url.startsWith('https://') && url.includes('.supabase')`
- Key: `anonKey.startsWith('eyJ') && anonKey.length > 20`
