### PR TITLE
fix: use actual value validation instead of placeholder check

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
                 return 'Supabase SDK failed to load (CDN blocked/offline)';
             }
 
-            if (!url || url.includes('YOUR_SUPABASE_URL')) {
+            if (!url || !url.startsWith('https://') || !url.includes('.supabase')) {
                 return 'Missing Supabase URL (placeholder not replaced; check SUPABASE_URL secret)';
             }
 
@@ -455,7 +455,7 @@
                 return 'Supabase URL is invalid';
             }
 
-            if (!anonKey || anonKey.includes('YOUR_SUPABASE_ANON_KEY')) {
+            if (!anonKey || !anonKey.startsWith('eyJ') || anonKey.length < 20) {
                 return 'Missing Supabase anon key (placeholder not replaced; check SUPABASE_ANON_KEY secret)';
             }
 


### PR DESCRIPTION
## Problem

The sed replacement was replacing ALL occurrences of YOUR_SUPABASE_URL, including in the validation check code. This caused the check to always fail.

## Fix

Changed validation from checking for placeholder to actual value validation:
- URL: starts with https:// and contains .supabase
- Key: starts with eyJ and length > 20
